### PR TITLE
Change build structure to allow building with MLC kick-off build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,31 @@ if(APPLE)
 
   # RPATH stuff
   set(CMAKE_MACOSX_RPATH ON)
+  # Determine if we can link against ML Compute
+  set(MLCOMPUTE_FOUND OFF)
+  execute_process(
+    COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
+    OUTPUT_VARIABLE _macosx_sdk_path
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  set(_SDK_SEARCH_PATH "${_macosx_sdk_path}/System/Library/Frameworks/")
+  set(_FRAMEWORK_SEARCH_PATH "/System/Library/Frameworks/")
+
+  find_library(_MLCompute_fwrk_path_ NAMES MLCompute REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(_MLCompute_sdk_path_ NAMES MLCompute REQUIRED PATHS ${_SDK_SEARCH_PATH} NO_DEFAULT_PATH)
+
+  if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mlc)
+    set(_MLC_FOLDER_EXISTS TRUE)
+  else()
+    set(_MLC_FOLDER_EXISTS FALSE)
+  endif()
+
+  if (_MLCompute_fwrk_path_ AND _MLCompute_sdk_path_ AND _MLC_FOLDER_EXISTS)
+    set(MLCOMPUTE_FOUND ON)
+    message(STATUS "ML Compute framework found")
+  else()
+    message(STATUS "ML Compute framework not found")
+  endif()
 endif()
 
 set(CPU_AARCH64 OFF)
@@ -181,6 +206,9 @@ option(USE_LMDB "Use LMDB" OFF)
 option(USE_METAL "Use Metal for Caffe2 iOS build" ON)
 option(USE_PYTORCH_METAL "Use Metal for PyTorch iOS build" OFF)
 option(USE_NATIVE_ARCH "Use -march=native" OFF)
+cmake_dependent_option(
+    USE_MLCOMPUTE "Use ML Compute for macOS build" ON
+    "MLCOMPUTE_FOUND" OFF)
 cmake_dependent_option(
     USE_NCCL "Use NCCL" ON
     "USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
@@ -754,6 +782,9 @@ if(USE_CPP_CODE_COVERAGE)
 endif()
 
 if(APPLE)
+    if (USE_MLCOMPUTE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_MLCOMPUTE -fobjc-arc -framework MLCompute -framework Metal")
+    endif()
     string(APPEND CMAKE_CXX_FLAGS " -Wno-unused-private-field")
     string(APPEND CMAKE_CXX_FLAGS " -Wno-missing-braces")
     string(APPEND CMAKE_CXX_FLAGS " -Wno-c++14-extensions")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -531,6 +531,10 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     endif()
   endif()
 
+  if(USE_MLCOMPUTE)
+    include(../mlc/mlc_build.cmake)
+  endif()
+
   if(USE_ROCM)
     list(APPEND Caffe2_HIP_SRCS ${Caffe2_GPU_HIP_JIT_FUSERS_SRCS})
     if(USE_NCCL)
@@ -1165,6 +1169,9 @@ if(USE_CUDA)
 elseif(USE_ROCM)
   target_link_libraries(torch PUBLIC torch_hip_library)
 endif()
+if(USE_MLCOMPUTE)
+  target_link_libraries(torch PUBLIC torch_mlc_library)
+endif()
 
 # Install PDB files for MSVC builds
 if(MSVC AND BUILD_SHARED_LIBS)
@@ -1472,6 +1479,7 @@ if(BUILD_PYTHON)
 
   # ---[ Python.
   if(BUILD_CAFFE2)
+  message("Caffe 2 Python sources: " ${Caffe2_CPU_PYTHON_SRCS})
   add_library(caffe2_pybind11_state MODULE ${Caffe2_CPU_PYTHON_SRCS})
   if(NOT MSVC)
     set_target_properties(caffe2_pybind11_state PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -156,6 +156,11 @@ if(USE_CUDNN OR USE_ROCM)
     endif()
 endif()
 
+if (USE_MLCOMPUTE)
+    list(APPEND TORCH_PYTHON_SRCS
+      ${MLC_PYTHON_SRCS})
+endif()
+
 if(USE_NUMPY)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NUMPY)
 endif()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -63,6 +63,10 @@
 #endif
 #endif
 
+#if defined(USE_MLCOMPUTE)
+#include <mlc/torch_mlc/csrc/MLCInit.h>
+#endif
+
 #if defined(USE_VALGRIND)
 #include <callgrind.h>
 #endif
@@ -753,6 +757,9 @@ PyObject* initModule() {
   torch::python::init_bindings(module);
 #ifdef USE_CUDA
   torch::cuda::initModule(module);
+#endif
+#ifdef USE_MLCOMPUTE
+  torch::mlc::init_bindings(module);
 #endif
   ASSERT_TRUE(THPDoubleStorage_init(module));
   ASSERT_TRUE(THPFloatStorage_init(module));


### PR DESCRIPTION
* Allows build process to build with MLC enabled if subrepo folder mlc is in path and we can link against ML Compute on macOS BigSur
* To build with MLC enabled you will need to clone the mlc repo inside the pytorch repository.
